### PR TITLE
feature/improve form group and array typing

### DIFF
--- a/projects/ngneat/reactive-forms/src/lib/formArray.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.ts
@@ -1,6 +1,14 @@
 import { FormArray as NgFormArray } from '@angular/forms';
-import { isObservable, Observable, Subject, Subscription } from 'rxjs';
-import { distinctUntilChanged, map } from 'rxjs/operators';
+import {
+  isObservable,
+  Observable,
+  Subject,
+  Subscription
+} from 'rxjs';
+import {
+  distinctUntilChanged,
+  map
+} from 'rxjs/operators';
 import {
   controlDisabled$,
   controlDisabledWhile,
@@ -17,7 +25,6 @@ import {
   mergeControlValidators
 } from './control-actions';
 import {
-  AbstractControl,
   AsyncValidator,
   ControlEventOptions,
   ControlOptions,
@@ -27,13 +34,15 @@ import {
   ExtractStrings,
   OnlySelf,
   Validator,
-  ValidatorOrOpts
+  ValidatorOrOpts,
+  ControlValue,
+  ControlOfValue
 } from './types';
 import { coerceArray } from './utils';
 
 export class FormArray<T = any, E extends object = any> extends NgFormArray {
-  readonly value: T[];
-  readonly valueChanges: Observable<T[]>;
+  readonly value: ControlValue<T>[];
+  readonly valueChanges: Observable<ControlValue<T>[]>;
   readonly status: ControlState;
   readonly statusChanges: Observable<ControlState>;
   readonly errors: E | null;
@@ -44,35 +53,35 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
   readonly touch$ = this.touchChanges.asObservable().pipe(distinctUntilChanged());
   readonly dirty$ = this.dirtyChanges.asObservable().pipe(distinctUntilChanged());
 
-  readonly value$ = controlValueChanges$<T[]>(this);
+  readonly value$ = controlValueChanges$<ControlValue<T>[]>(this);
   readonly disabled$ = controlDisabled$(this);
   readonly enabled$ = controlEnabled$(this);
   readonly status$ = controlStatusChanges$(this);
   readonly errors$ = controlErrorChanges$<E>(this);
 
   constructor(
-    public controls: Array<AbstractControl<T>>,
+    public controls: Array<ControlOfValue<T>>,
     validatorOrOpts?: ValidatorOrOpts,
     asyncValidator?: AsyncValidator
   ) {
     super(controls, validatorOrOpts, asyncValidator);
   }
 
-  select<R>(mapFn: (state: T[]) => R): Observable<R> {
+  select<R>(mapFn: (state: ControlValue<T>[]) => R): Observable<R> {
     return this.value$.pipe(map(mapFn), distinctUntilChanged());
   }
 
-  getRawValue(): T[] {
+  getRawValue(): ControlValue<T>[] {
     return super.getRawValue();
   }
 
-  at(index: number): AbstractControl<T> {
-    return super.at(index) as AbstractControl<T>;
+  at(index: number): ControlOfValue<T> {
+    return super.at(index) as ControlOfValue<T>;
   }
 
-  setValue(valueOrObservable: Observable<T[]>, options?: ControlEventOptions): Subscription;
-  setValue(valueOrObservable: T[], options?: ControlEventOptions): void;
-  setValue(valueOrObservable: T[] | Observable<T[]>, options?: ControlEventOptions): Subscription | void {
+  setValue(valueOrObservable: Observable<ControlValue<T>[]>, options?: ControlEventOptions): Subscription;
+  setValue(valueOrObservable: ControlValue<T>[], options?: ControlEventOptions): void;
+  setValue(valueOrObservable: ControlValue<T>[] | Observable<ControlValue<T>[]>, options?: ControlEventOptions): Subscription | void {
     if (isObservable(valueOrObservable)) {
       return valueOrObservable.subscribe(value => super.setValue(value, options));
     }
@@ -80,8 +89,8 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     super.setValue(valueOrObservable, options);
   }
 
-  patchValue(valueOrObservable: Observable<T[]>, options?: ControlEventOptions): Subscription;
-  patchValue(valueOrObservable: T[], options?: ControlEventOptions): void;
+  patchValue(valueOrObservable: Observable<Partial<ControlValue<T>>[]>, options?: ControlEventOptions): Subscription;
+  patchValue(valueOrObservable: Partial<ControlValue<T>>[], options?: ControlEventOptions): void;
   patchValue(valueOrObservable: any, options?: ControlEventOptions): Subscription | void {
     if (isObservable(valueOrObservable)) {
       return valueOrObservable.subscribe((value: T[]) => super.patchValue(value, options));
@@ -90,15 +99,15 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     super.patchValue(valueOrObservable as T[], options);
   }
 
-  push(control: AbstractControl<T>): void {
+  push(control: ControlOfValue<T>): void {
     return super.push(control);
   }
 
-  insert(index: number, control: AbstractControl<T>): void {
+  insert(index: number, control: ControlOfValue<T>): void {
     return super.insert(index, control);
   }
 
-  setControl(index: number, control: AbstractControl<T>): void {
+  setControl(index: number, control: ControlOfValue<T>): void {
     return super.setControl(index, control);
   }
 
@@ -143,7 +152,7 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     markAllDirty(this);
   }
 
-  reset(value?: T[], options?: ControlEventOptions): void {
+  reset(value?: ControlValue<T>[], options?: ControlEventOptions): void {
     super.reset(value, options);
   }
 

--- a/projects/ngneat/reactive-forms/src/lib/formBuilder.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formBuilder.ts
@@ -55,7 +55,6 @@ export class FormBuilder extends NgFormBuilder {
       }
     }
 
-    // Todo: dan remove the any
     return new FormGroup(controls, { asyncValidators, updateOn, validators });
   }
 

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.ts
@@ -1,5 +1,10 @@
 import { FormGroup as NgFormGroup } from '@angular/forms';
-import { isObservable, Observable, Subject, Subscription } from 'rxjs';
+import {
+  isObservable,
+  Observable,
+  Subject,
+  Subscription
+} from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 import {
   controlDisabled$,
@@ -31,14 +36,18 @@ import {
   Obj,
   OnlySelf,
   Validator,
-  ValidatorOrOpts
+  ValidatorOrOpts,
+  ControlsValue,
+  ControlsOfValue
 } from './types';
 import { coerceArray } from './utils';
+import { FormArray } from './formArray';
 
-export class FormGroup<T extends Obj = any, E extends object = any> extends NgFormGroup {
-  readonly value: T;
+export class FormGroup<T extends Obj = any,
+  E extends object = any> extends NgFormGroup {
+  readonly value: ControlsValue<T>;
   readonly errors: E | null;
-  readonly valueChanges: Observable<T>;
+  readonly valueChanges: Observable<ControlsValue<T>>;
   readonly status: ControlState;
   readonly statusChanges: Observable<ControlState>;
 
@@ -48,56 +57,67 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
   touch$ = this.touchChanges.asObservable().pipe(distinctUntilChanged());
   dirty$ = this.dirtyChanges.asObservable().pipe(distinctUntilChanged());
 
-  readonly value$ = controlValueChanges$<T>(this);
-  readonly disabled$ = controlDisabled$<T>(this);
-  readonly enabled$ = controlEnabled$<T>(this);
-  readonly status$ = controlStatusChanges$<T>(this);
+  readonly value$ = controlValueChanges$<ControlsValue<T>>(this);
+  readonly disabled$ = controlDisabled$<ControlsValue<T>>(this);
+  readonly enabled$ = controlEnabled$<ControlsValue<T>>(this);
+  readonly status$ = controlStatusChanges$<ControlsValue<T>>(this);
   readonly errors$ = controlErrorChanges$<E>(this);
 
-  constructor(
-    public controls: ExtractAbstractControl<KeyValueControls<T>, T>,
-    validatorOrOpts?: ValidatorOrOpts,
-    asyncValidator?: AsyncValidator
-  ) {
+  constructor(public controls: ControlsOfValue<T>, validatorOrOpts?: ValidatorOrOpts, asyncValidator?: AsyncValidator) {
     super(controls, validatorOrOpts, asyncValidator);
   }
 
-  select<R>(mapFn: (state: T) => R): Observable<R> {
+  select<R>(mapFn: (state: ControlsValue<T>) => R): Observable<R> {
     return selectControlValue$(this, mapFn);
   }
 
-  getRawValue(): T {
+  getRawValue(): ControlsValue<T> {
     return super.getRawValue();
   }
 
-  get<K1 extends keyof T>(path?: [K1]): AbstractControl<T[K1]>;
-  get<K1 extends keyof T, K2 extends keyof T[K1]>(path?: [K1, K2]): AbstractControl<T[K1][K2]>;
-  get<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(
-    path?: [K1, K2, K3]
-  ): AbstractControl<T[K1][K2][K3]>;
-  get(path?: string): AbstractControl;
-  get(path: any) {
+  get<K1 extends keyof ControlsValue<T>>(path?: [K1]): ControlsOfValue<T>[K1];
+  get<K1 extends keyof ControlsValue<T>,
+    K2 extends (ControlsOfValue<T>[K1] extends FormGroup | FormArray ? keyof ControlsOfValue<T>[K1]['controls'] : never)>(path?: [K1, K2]): ControlsOfValue<T>[K1] extends FormGroup | FormArray
+    ? ControlsOfValue<T>[K1]['controls'][K2]
+    : never;
+  get<K1 extends keyof ControlsValue<T>,
+    K2 extends keyof ControlsValue<T>[K1]>(path?: [K1, K2]): AbstractControl<ControlsValue<T>[K1][K2]>;
+  get<K1 extends keyof ControlsValue<T>,
+    K2 extends keyof ControlsValue<T>[K1],
+    K3 extends keyof ControlsValue<T>[K1][K2],
+    >(path?: [K1, K2, K3]): AbstractControl<ControlsValue<T>[K1][K2][K3]>;
+  get(path?: Array<string | number> | string): AbstractControl;
+  get(path: Array<string | number> | string) {
     return super.get(path);
   }
 
-  getControl<P1 extends keyof T>(prop1: P1): AbstractControl<T[P1]>;
-  getControl<P1 extends keyof T, P2 extends keyof T[P1]>(prop1: P1, prop2: P2): AbstractControl<T[P1][P2]>;
-  getControl<P1 extends keyof T, P2 extends keyof T[P1], P3 extends keyof T[P1][P2]>(
+  getControl<P1 extends keyof ControlsValue<T>>(path?: P1): ControlsOfValue<T>[P1];
+  getControl<P1 extends keyof ControlsValue<T>,
+    P2 extends (ControlsOfValue<T>[P1] extends FormGroup | FormArray ? keyof ControlsOfValue<T>[P1]['controls'] : never)>(
     prop1: P1,
     prop2: P2,
-    prop3: P3
-  ): AbstractControl<T[P1][P2][P3]>;
-  getControl<P1 extends keyof T, P2 extends keyof T[P1], P3 extends keyof T[P1][P2], P4 extends keyof T[P1][P2][P3]>(
+  ): ControlsOfValue<T>[P1] extends FormGroup | FormArray
+    ? ControlsOfValue<T>[P1]['controls'][P2]
+    : never;
+  getControl<P1 extends keyof ControlsValue<T>,
+    P2 extends keyof ControlsValue<T>[P1]>(
+    prop1: P1,
+    prop2: P2,
+  ): AbstractControl<ControlsValue<T>[P1][P2]>;
+  getControl<P1 extends keyof ControlsValue<T>,
+    P2 extends keyof ControlsValue<T>[P1],
+    P3 extends keyof ControlsValue<T>[P1][P2],
+    >(
     prop1: P1,
     prop2: P2,
     prop3: P3,
-    prop4: P4
-  ): AbstractControl<T[P1][P2][P3][P4]>;
-  getControl(...names: any): AbstractControl<any> {
-    return this.get(names.join('.'));
+  ): AbstractControl<ControlsValue<T>[P1][P2][P3]>;
+  getControl(path?: string): AbstractControl;
+  getControl(...names: Array<string | number>): AbstractControl<any> {
+    return this.get(names);
   }
 
-  addControl<K extends ExtractStrings<T>>(name: K, control: AbstractControl<T[K]>): void {
+  addControl<K extends ExtractStrings<T>>(name: K, control: ControlsOfValue<T>[K]): void {
     super.addControl(name, control);
   }
 
@@ -109,12 +129,12 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     return super.contains(controlName);
   }
 
-  setControl<K extends ExtractStrings<T>>(name: K, control: AbstractControl<T[K]>): void {
+  setControl<K extends ExtractStrings<T>>(name: K, control: ControlsOfValue<T>[K]): void {
     super.setControl(name, control);
   }
 
-  setValue(valueOrObservable: Observable<T>, options?: ControlEventOptions): Subscription;
-  setValue(valueOrObservable: T, options?: ControlEventOptions): void;
+  setValue(valueOrObservable: Observable<ControlsValue<T>>, options?: ControlEventOptions): Subscription;
+  setValue(valueOrObservable: ControlsValue<T>, options?: ControlEventOptions): void;
   setValue(valueOrObservable: any, options?: ControlEventOptions): any {
     if (isObservable(valueOrObservable)) {
       return valueOrObservable.subscribe(value => super.setValue(value, options));
@@ -123,8 +143,8 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     super.setValue(valueOrObservable, options);
   }
 
-  patchValue(valueOrObservable: Observable<Partial<T>>, options?: ControlEventOptions): Subscription;
-  patchValue(valueOrObservable: Partial<T>, options?: ControlEventOptions): void;
+  patchValue(valueOrObservable: Observable<Partial<ControlsValue<T>>>, options?: ControlEventOptions): Subscription;
+  patchValue(valueOrObservable: Partial<ControlsValue<T>>, options?: ControlEventOptions): void;
   patchValue(valueOrObservable: any, options?: ControlEventOptions): Subscription | void {
     if (isObservable(valueOrObservable)) {
       return valueOrObservable.subscribe(value => super.patchValue(value, options));
@@ -174,7 +194,7 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     markAllDirty(this);
   }
 
-  reset(formState?: Partial<T>, options?: ControlEventOptions): void {
+  reset(formState?: Partial<ControlsValue<T>>, options?: ControlEventOptions): void {
     super.reset(formState, options);
   }
 
@@ -192,12 +212,14 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     return validateControlOn(this, observableValidation);
   }
 
-  hasError<K1 extends keyof T>(errorCode: ExtractStrings<E>, path?: [K1]): boolean;
-  hasError<K1 extends keyof T, K2 extends keyof T[K1]>(errorCode: ExtractStrings<E>, path?: [K1, K2]): boolean;
-  hasError<K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(
+  hasError<K1 extends keyof ControlsValue<T>>(errorCode: ExtractStrings<E>, path?: [K1]): boolean;
+  hasError<K1 extends keyof ControlsValue<T>, K2 extends keyof ControlsValue<T>[K1]>(
     errorCode: ExtractStrings<E>,
-    path?: [K1, K2, K3]
+    path?: [K1, K2]
   ): boolean;
+  hasError<K1 extends keyof ControlsValue<T>,
+    K2 extends keyof ControlsValue<T>[K1],
+    K3 extends keyof ControlsValue<T>[K1][K2]>(errorCode: ExtractStrings<E>, path?: [K1, K2, K3]): boolean;
   hasError(errorCode: ExtractStrings<E>, path?: string): boolean;
   hasError(errorCode: ExtractStrings<E>, path?: any): boolean {
     return super.hasError(errorCode, path);
@@ -207,57 +229,50 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     return super.setErrors(errors, opts);
   }
 
-  getError<K extends keyof E, K1 extends keyof T>(errorCode: K, path?: [K1]): E[K] | null;
-  getError<K extends keyof E, K1 extends keyof T, K2 extends keyof T[K1]>(errorCode: K, path?: [K1, K2]): E[K] | null;
-  getError<K extends keyof E, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(
+  getError<K extends keyof E, K1 extends keyof ControlsValue<T>>(errorCode: K, path?: [K1]): E[K] | null;
+  getError<K extends keyof E, K1 extends keyof ControlsValue<T>, K2 extends keyof ControlsValue<T>[K1]>(
     errorCode: K,
-    path?: [K1, K2, K3]
+    path?: [K1, K2]
   ): E[K] | null;
+  getError<K extends keyof E,
+    K1 extends keyof ControlsValue<T>,
+    K2 extends keyof ControlsValue<T>[K1],
+    K3 extends keyof ControlsValue<T>[K1][K2]>(errorCode: K, path?: [K1, K2, K3]): E[K] | null;
   getError<K extends keyof E>(errorCode: K, path?: string): E[K] | null;
   getError<K extends keyof E>(errorCode: K, path?: any): E[K] | null {
     return super.getError(errorCode as any, path) as E[K] | null;
   }
 
-  hasErrorAndTouched<P1 extends keyof T>(error: ExtractStrings<E>, prop1?: P1): boolean;
-  hasErrorAndTouched<P1 extends keyof T, P2 extends keyof T[P1]>(
+  hasErrorAndTouched<P1 extends keyof ControlsValue<T>>(error: ExtractStrings<E>, prop1?: P1): boolean;
+  hasErrorAndTouched<P1 extends keyof ControlsValue<T>, P2 extends keyof ControlsValue<T>[P1]>(
     error: ExtractStrings<E>,
     prop1?: P1,
     prop2?: P2
   ): boolean;
-  hasErrorAndTouched<P1 extends keyof T, P2 extends keyof T[P1], P3 extends keyof T[P1][P2]>(
-    error: ExtractStrings<E>,
-    prop1?: P1,
-    prop2?: P2,
-    prop3?: P3
-  ): boolean;
-  hasErrorAndTouched<
-    P1 extends keyof T,
-    P2 extends keyof T[P1],
-    P3 extends keyof T[P1][P2],
-    P4 extends keyof T[P1][P2][P3]
-  >(error: ExtractStrings<E>, prop1?: P1, prop2?: P2, prop3?: P3, prop4?: P4): boolean;
+  hasErrorAndTouched<P1 extends keyof ControlsValue<T>,
+    P2 extends keyof ControlsValue<T>[P1],
+    P3 extends keyof ControlsValue<T>[P1][P2]>(error: ExtractStrings<E>, prop1?: P1, prop2?: P2, prop3?: P3): boolean;
+  hasErrorAndTouched<P1 extends keyof ControlsValue<T>,
+    P2 extends keyof ControlsValue<T>[P1],
+    P3 extends keyof ControlsValue<T>[P1][P2],
+    P4 extends keyof ControlsValue<T>[P1][P2][P3]>(error: ExtractStrings<E>, prop1?: P1, prop2?: P2, prop3?: P3, prop4?: P4): boolean;
   hasErrorAndTouched(error: any, ...path: any): boolean {
     return hasErrorAndTouched(this, error, ...path);
   }
 
-  hasErrorAndDirty<P1 extends keyof T>(error: ExtractStrings<E>, prop1?: P1): boolean;
-  hasErrorAndDirty<P1 extends keyof T, P2 extends keyof T[P1]>(
+  hasErrorAndDirty<P1 extends keyof ControlsValue<T>>(error: ExtractStrings<E>, prop1?: P1): boolean;
+  hasErrorAndDirty<P1 extends keyof ControlsValue<T>, P2 extends keyof ControlsValue<T>[P1]>(
     error: ExtractStrings<E>,
     prop1?: P1,
     prop2?: P2
   ): boolean;
-  hasErrorAndDirty<P1 extends keyof T, P2 extends keyof T[P1], P3 extends keyof T[P1][P2]>(
-    error: ExtractStrings<E>,
-    prop1?: P1,
-    prop2?: P2,
-    prop3?: P3
-  ): boolean;
-  hasErrorAndDirty<
-    P1 extends keyof T,
-    P2 extends keyof T[P1],
-    P3 extends keyof T[P1][P2],
-    P4 extends keyof T[P1][P2][P3]
-  >(error: ExtractStrings<E>, prop1?: P1, prop2?: P2, prop3?: P3, prop4?: P4): boolean;
+  hasErrorAndDirty<P1 extends keyof ControlsValue<T>,
+    P2 extends keyof ControlsValue<T>[P1],
+    P3 extends keyof ControlsValue<T>[P1][P2]>(error: ExtractStrings<E>, prop1?: P1, prop2?: P2, prop3?: P3): boolean;
+  hasErrorAndDirty<P1 extends keyof ControlsValue<T>,
+    P2 extends keyof ControlsValue<T>[P1],
+    P3 extends keyof ControlsValue<T>[P1][P2],
+    P4 extends keyof ControlsValue<T>[P1][P2][P3]>(error: ExtractStrings<E>, prop1?: P1, prop2?: P2, prop3?: P3, prop4?: P4): boolean;
   hasErrorAndDirty(error: any, ...path: any): boolean {
     return hasErrorAndDirty(this, error, ...path);
   }

--- a/projects/ngneat/reactive-forms/src/lib/type-tests/formArray.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/type-tests/formArray.spec.ts
@@ -1,9 +1,25 @@
 import { expectTypeOf } from 'expect-type';
-import { Observable, of, Subscription } from 'rxjs';
+import {
+  Observable,
+  of,
+  Subscription
+} from 'rxjs';
 import { FormArray } from '../formArray';
 import { FormControl } from '../formControl';
 import { FormGroup } from '../formGroup';
-import { User, user, Errors, required, pattern, patternAsync, requiredAsync, errors } from './mocks.spec';
+import {
+  User,
+  user,
+  Errors,
+  required,
+  pattern,
+  patternAsync,
+  requiredAsync,
+  errors,
+  NestedForm,
+  NestedFormControls,
+  nestedFormValue
+} from './mocks.spec';
 
 test('control should be constructed with abstract controls', () => {
   expectTypeOf(FormArray).toBeConstructibleWith([new FormControl<User>()]);
@@ -14,9 +30,19 @@ test('control value should be of type User[]', () => {
   expectTypeOf(control.value).toEqualTypeOf([user]);
 });
 
+test('control value should be constructed according to generic control type', () => {
+  const control = new FormArray<FormGroup<NestedFormControls>>([]);
+  expectTypeOf<NestedForm[]>(control.value).toEqualTypeOf([nestedFormValue]);
+})
+
 test('control valueChanges$ should be of type stream of User[]', () => {
   const control = new FormArray<User>([]);
   expectTypeOf(control.value$).toMatchTypeOf(new Observable<User[]>());
+});
+
+test('control valueChanges$ should be of type stream of the controls type', () => {
+  const control = new FormArray<FormGroup<NestedFormControls>>([]);
+  expectTypeOf(control.value$).toMatchTypeOf(new Observable<NestedForm[]>());
 });
 
 test('control toucheChanges$ should be of type stream of boolean', () => {
@@ -132,7 +158,10 @@ test('should be able to insert groups', () => {
     0,
     new FormGroup<User>({ id: new FormControl(1) })
   );
-  control.setControl(1, new FormGroup<any>({}));
+  control.setControl(
+    0,
+    new FormGroup<User>({ id: new FormControl(2) })
+  );
 });
 
 test('should be able to set value to controls', () => {
@@ -157,7 +186,7 @@ test('should be able to set value to groups', () => {
 });
 
 test('should be able to set value to control inside group', () => {
-  const control = new FormArray<User>([]);
+  const control = new FormArray<FormGroup<User>>([]);
   control.setControl(
     0,
     new FormGroup<User>({ id: new FormControl<number>() })
@@ -166,5 +195,5 @@ test('should be able to set value to control inside group', () => {
     .at(0)
     .get('id')
     .setValue(3);
-  expectTypeOf((control.at(0) as FormGroup<User>).getControl('id').value).toBeNumber();
+  expectTypeOf((control.at(0)).getControl('id').value).toBeNumber();
 });

--- a/projects/ngneat/reactive-forms/src/lib/type-tests/mocks.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/type-tests/mocks.spec.ts
@@ -1,4 +1,10 @@
 import { of } from 'rxjs';
+import { ControlsOfValue } from '../types';
+import {
+  FormControl,
+  FormGroup,
+  FormArray
+} from '@ngneat/reactive-forms';
 
 export interface NestedForm {
   a: number;
@@ -7,6 +13,15 @@ export interface NestedForm {
     c: number[];
   };
   c?: { a: number }[];
+}
+
+export interface NestedFormControls {
+  a: FormControl<number>,
+  b: FormGroup<{
+    a: FormControl<string>,
+    c: FormArray<FormControl<number>>,
+  }>,
+  c: FormArray<FormGroup<{ a: number }>>
 }
 
 export interface User {
@@ -18,6 +33,14 @@ export interface Errors {
   pattern: { requiredPattern: string; actualValue: string };
 }
 export const user: User = { id: 1, name: 'Itay' };
+export const nestedFormValue: NestedForm = {
+  a: 1,
+  b: {
+    a: '1',
+    c: [1],
+  },
+  c: [{a: 2}],
+}
 export const errors: Errors = { required: true, pattern: { requiredPattern: '*', actualValue: '*' } };
 export const required = control => ({ required: true });
 export const pattern = control => ({ pattern: { requiredPattern: '*', actualValue: '*' } });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,15 +1,14 @@
 import { Component } from '@angular/core';
 import { FormGroup, FormControl, FormArray } from '@ngneat/reactive-forms';
-// import { FormGroup, FormControl } from '@angular/forms';
 
 interface Profile {
   firstName: string;
   lastName: string;
   skills: string[];
-  controlArray: string[],
+  controlArray: string[];
   controlObject: {
-    key: string
-  },
+    key: string;
+  };
   address: {
     street: string;
     city: string;
@@ -19,7 +18,7 @@ interface Profile {
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   profileForm = new FormGroup<Profile>({
@@ -27,17 +26,7 @@ export class AppComponent {
     lastName: new FormControl(''),
     skills: new FormArray([]),
     controlArray: new FormControl([]),
-    controlObject: new FormControl({value: { key: ''}}),
-    address: new FormGroup({
-      street: new FormControl(''),
-      city: new FormControl('')
-    })
-  });
-
-  legacyForm = new FormGroup({
-    firstName: new FormControl(''),
-    skills: new FormArray([]),
-    lastName: new FormControl(''),
+    controlObject: new FormControl({ value: { key: '' } }),
     address: new FormGroup({
       street: new FormControl(''),
       city: new FormControl('')
@@ -45,7 +34,7 @@ export class AppComponent {
   });
 
   ngOnInit() {
-    this.profileForm.patchValue({firstName: 'Netanel'});
+    this.profileForm.patchValue({ firstName: 'Netanel' });
   }
 
   get skills() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

From the current documentation:

```ts
import { FormGroup } from '@ngneat/reactive-forms';

const group = new FormGroup<Profile>(...);
const address = group.getControl('name') as FormGroup<Profile['address']>;
const city = group.getControl('address', 'city') as FormControl<string>;
```

**"Note that the return type should still be inferred."** - This PR is fixing this issue.

## What is the new behavior?

I'm enabling passing the type of the control / controls **in addition** to the current ability to pass the value type to `FormGroup` or `FormArray`.
For example, this way I can differ between those two, otherwise identical, Form Groups:
```ts
const group1 = new FormGroup<{
  name: string, // for primitive types, FormControl is inferred, instead of AbstractControl, which is what it was before.
  address: FormControl<{ city: string, street: string }>
}>({
  name: new FormControl('Shachar'),
  address: new FormControl({
    city: 'Tel Aviv',
    street: 'Ibn Gavirol'
  }),
})

const group2 = new FormGroup<{
  name: string, // for primitive types, FormControl is inferred, instead of AbstractControl, which is what it was before.
  address: FormGroup<{ city: string, street: string }>
}>({
  name: new FormControl('Shachar'),
  address: new FormGroup({
    city: new FormControl('Tel Aviv'),
    street: new FormControl('Ibn Gavirol')
  }),
})
```

Now I'll get automatic inference for the controls type:

```ts
const control1 = group1.getControl('address'); // FormControl<{city: string, street: string}> is inferred
const control2 = group1.getControl('address'); // FormGroup<{city: string, street: string}> is inferred
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

Note those changes are completely backward compatible! For evidence, I did not change existing tests and they all pass.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->