### PR TITLE
feat: provide a mergeErrors helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ const city = group.getControl('address', 'city') as FormControl<string>;
 
 ### `mergeErrors()`
 
-A helper method to merge validation errors. Unlike `setErrors()`, this will not overwrite errors already held by the control.
+Merge validation errors. Unlike `setErrors()`, this will not overwrite errors already held by the control.
 
 ```ts
 import { FormGroup } from '@ngneat/reactive-forms';
@@ -369,7 +369,7 @@ group.mergeErrors({ customError: true });
 
 ### `removeError()`
 
-A helper method to remove an error by key from the control.
+Remove an error by key from the control.
 
 ```ts
 import { FormGroup } from '@ngneat/reactive-forms';

--- a/README.md
+++ b/README.md
@@ -356,6 +356,28 @@ const city = group.getControl('address', 'city') as FormControl<string>;
 
 **Note that the return type should still be inferred.**
 
+### `mergeErrors()`
+
+A helper method to merge validation errors. Unlike `setErrors()`, this will not overwrite errors already held by the control.
+
+```ts
+import { FormGroup } from '@ngneat/reactive-forms';
+
+const group = new FormGroup<Profile>(...);
+group.mergeErrors({ customError: true });
+```
+
+### `removeError()`
+
+A helper method to remove an error by key from the control.
+
+```ts
+import { FormGroup } from '@ngneat/reactive-forms';
+
+const group = new FormGroup<Profile>(...);
+group.removeError('customError');
+```
+
 ### FormArray methods
 
 ### remove()

--- a/projects/ngneat/reactive-forms/src/lib/formArray.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.spec.ts
@@ -196,6 +196,13 @@ describe('FormArray', () => {
     expect(control.errors).toEqual({ isInvalid: true, customError: true });
   });
 
+  it('should removeError', () => {
+    const control = createArray();
+    control.setErrors({ customError: true, otherError: true });
+    control.removeError('otherError');
+    expect(control.errors).toEqual({ customError: true });
+  });
+
   it('should setEnable', () => {
     const control = createArray();
 

--- a/projects/ngneat/reactive-forms/src/lib/formArray.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.spec.ts
@@ -184,6 +184,18 @@ describe('FormArray', () => {
     expect(control.hasErrorAndDirty('isInvalid')).toBeTruthy();
   });
 
+  it('should setErrors', () => {
+    const control = createArray(true);
+    control.setErrors({ customError: true });
+    expect(control.errors).toEqual({ customError: true });
+  });
+
+  it('should mergeErrors', () => {
+    const control = createArray(true);
+    control.mergeErrors({ customError: true });
+    expect(control.errors).toEqual({ isInvalid: true, customError: true });
+  });
+
   it('should setEnable', () => {
     const control = createArray();
 

--- a/projects/ngneat/reactive-forms/src/lib/formArray.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.ts
@@ -29,7 +29,7 @@ import {
   Validator,
   ValidatorOrOpts
 } from './types';
-import { coerceArray } from './utils';
+import { coerceArray, mergeErrors, removeError } from './utils';
 
 export class FormArray<T = any, E extends object = any> extends NgFormArray {
   readonly value: T[];
@@ -172,13 +172,11 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
   }
 
   mergeErrors(errors: Partial<E>, opts: EmitEvent = {}): void {
-    this.setErrors(
-      {
-        ...this.errors,
-        ...errors
-      },
-      opts
-    );
+    this.setErrors(mergeErrors<E>(this.errors, errors), opts);
+  }
+
+  removeError(key: keyof E, opts: EmitEvent = {}): void {
+    this.setErrors(removeError<E>(this.errors, key), opts);
   }
 
   getError<K extends ExtractStrings<E>>(errorCode: K, path?: ControlPath) {

--- a/projects/ngneat/reactive-forms/src/lib/formArray.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.ts
@@ -171,6 +171,16 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     return super.setErrors(errors, opts);
   }
 
+  mergeErrors(errors: Partial<E>, opts: EmitEvent = {}): void {
+    this.setErrors(
+      {
+        ...this.errors,
+        ...errors
+      },
+      opts
+    );
+  }
+
   getError<K extends ExtractStrings<E>>(errorCode: K, path?: ControlPath) {
     return super.getError(errorCode, path) as E[K] | null;
   }

--- a/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
@@ -191,6 +191,18 @@ describe('FormControl', () => {
     expect(control.enabled).toBe(false);
   });
 
+  it('should setErrors', () => {
+    const control = new FormControl<string>('', Validators.required);
+    control.setErrors({ customError: true });
+    expect(control.errors).toEqual({ customError: true });
+  });
+
+  it('should mergeErrors', () => {
+    const control = new FormControl<string>('', Validators.required);
+    control.mergeErrors({ customError: true });
+    expect(control.errors).toEqual({ required: true, customError: true });
+  });
+
   it('should setDisable', () => {
     const control = new FormControl<string>();
     control.setDisable();

--- a/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
@@ -209,6 +209,12 @@ describe('FormControl', () => {
     expect(control.errors).toEqual({ customError: true });
   });
 
+  it('should mergeErrors when no previous errors and null is given', () => {
+    const control = new FormControl<string>('');
+    control.mergeErrors(null);
+    expect(control.errors).toEqual(null);
+  });
+
   it('should removeError correctly with two existing errors', () => {
     const control = new FormControl<string>('');
     control.setErrors({ customError: true, otherError: true });

--- a/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
@@ -197,10 +197,37 @@ describe('FormControl', () => {
     expect(control.errors).toEqual({ customError: true });
   });
 
-  it('should mergeErrors', () => {
+  it('should mergeErrors with previous errors', () => {
     const control = new FormControl<string>('', Validators.required);
     control.mergeErrors({ customError: true });
     expect(control.errors).toEqual({ required: true, customError: true });
+  });
+
+  it('should mergeErrors when no previous errors', () => {
+    const control = new FormControl<string>('');
+    control.mergeErrors({ customError: true });
+    expect(control.errors).toEqual({ customError: true });
+  });
+
+  it('should removeError correctly with two existing errors', () => {
+    const control = new FormControl<string>('');
+    control.setErrors({ customError: true, otherError: true });
+    control.removeError('otherError');
+    expect(control.errors).toEqual({ customError: true });
+  });
+
+  it('should removeError correctly last error', () => {
+    const control = new FormControl<string>('');
+    control.setErrors({ customError: true });
+    control.removeError('customError');
+    expect(control.errors).toEqual(null);
+  });
+
+  it('should removeError with not existing errors', () => {
+    const control = new FormControl<string>('');
+    control.setErrors({ customError: true });
+    control.removeError('notExisting');
+    expect(control.errors).toEqual({ customError: true });
   });
 
   it('should setDisable', () => {

--- a/projects/ngneat/reactive-forms/src/lib/formControl.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.ts
@@ -146,6 +146,16 @@ export class FormControl<T = any, E extends object = any> extends NgFormControl 
     return super.setErrors(errors, opts);
   }
 
+  mergeErrors(errors: Partial<E>, opts: EmitEvent = {}): void {
+    this.setErrors(
+      {
+        ...this.errors,
+        ...errors
+      },
+      opts
+    );
+  }
+
   hasErrorAndTouched(error: ExtractStrings<E>): boolean {
     return hasErrorAndTouched(this, error);
   }

--- a/projects/ngneat/reactive-forms/src/lib/formControl.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.ts
@@ -29,7 +29,7 @@ import {
   Validator,
   ValidatorOrOpts
 } from './types';
-import { coerceArray } from './utils';
+import { coerceArray, mergeErrors, removeError } from './utils';
 
 export class FormControl<T = any, E extends object = any> extends NgFormControl {
   readonly value: T;
@@ -147,13 +147,11 @@ export class FormControl<T = any, E extends object = any> extends NgFormControl 
   }
 
   mergeErrors(errors: Partial<E>, opts: EmitEvent = {}): void {
-    this.setErrors(
-      {
-        ...this.errors,
-        ...errors
-      },
-      opts
-    );
+    this.setErrors(mergeErrors<E>(this.errors, errors), opts);
+  }
+
+  removeError(key: keyof E, opts: EmitEvent = {}): void {
+    this.setErrors(removeError<E>(this.errors, key), opts);
   }
 
   hasErrorAndTouched(error: ExtractStrings<E>): boolean {

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.spec.ts
@@ -224,6 +224,18 @@ describe('FormGroup', () => {
     expect(control.reset).toHaveBeenCalled();
   });
 
+  it('should setErrors', () => {
+    const control = createGroup(true);
+    control.setErrors({ customError: true });
+    expect(control.errors).toEqual({ customError: true });
+  });
+
+  it('should mergeErrors', () => {
+    const control = createGroup(true);
+    control.mergeErrors({ customError: true });
+    expect(control.errors).toEqual({ isInvalid: true, customError: true });
+  });
+
   it('should setValidators', () => {
     const control = createGroup();
     spyOn(control, 'setValidators');

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.spec.ts
@@ -236,6 +236,13 @@ describe('FormGroup', () => {
     expect(control.errors).toEqual({ isInvalid: true, customError: true });
   });
 
+  it('should removeError', () => {
+    const control = createGroup();
+    control.setErrors({ customError: true, otherError: true });
+    control.removeError('otherError');
+    expect(control.errors).toEqual({ customError: true });
+  });
+
   it('should setValidators', () => {
     const control = createGroup();
     spyOn(control, 'setValidators');

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.ts
@@ -37,7 +37,7 @@ import {
   PersistOptions,
   ControlFactoryMap
 } from './types';
-import { coerceArray, wrapIntoObservable } from './utils';
+import { coerceArray, wrapIntoObservable, mergeErrors, removeError } from './utils';
 import { PersistManager } from './persistManager';
 import { LocalStorageManager } from './localStorageManager';
 import { FormArray } from './formArray';
@@ -215,13 +215,11 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
   }
 
   mergeErrors(errors: Partial<E>, opts: EmitEvent = {}): void {
-    this.setErrors(
-      {
-        ...this.errors,
-        ...errors
-      },
-      opts
-    );
+    this.setErrors(mergeErrors<E>(this.errors, errors), opts);
+  }
+
+  removeError(key: keyof E, opts: EmitEvent = {}): void {
+    this.setErrors(removeError<E>(this.errors, key), opts);
   }
 
   getError<K extends keyof E, K1 extends keyof T>(errorCode: K, path?: [K1]): E[K] | null;

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.ts
@@ -214,6 +214,16 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     return super.setErrors(errors, opts);
   }
 
+  mergeErrors(errors: Partial<E>, opts: EmitEvent = {}): void {
+    this.setErrors(
+      {
+        ...this.errors,
+        ...errors
+      },
+      opts
+    );
+  }
+
   getError<K extends keyof E, K1 extends keyof T>(errorCode: K, path?: [K1]): E[K] | null;
   getError<K extends keyof E, K1 extends keyof T, K2 extends keyof T[K1]>(errorCode: K, path?: [K1, K2]): E[K] | null;
   getError<K extends keyof E, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(

--- a/projects/ngneat/reactive-forms/src/lib/utils.ts
+++ b/projects/ngneat/reactive-forms/src/lib/utils.ts
@@ -23,3 +23,23 @@ export function wrapIntoObservable<T>(value: T | Promise<T> | Observable<T>): Ob
 
   return of(value);
 }
+
+export function mergeErrors<E>(existing: Partial<E>, toAdd: Partial<E>) {
+  return existing
+    ? {
+        ...existing,
+        ...toAdd
+      }
+    : toAdd;
+}
+
+export function removeError<E>(errors: E, key: keyof E) {
+  if (!errors) {
+    return null;
+  }
+  const updatedErrors = {
+    ...errors
+  };
+  delete updatedErrors[key];
+  return Object.keys(updatedErrors).length > 0 ? updatedErrors : null;
+}

--- a/projects/ngneat/reactive-forms/src/lib/utils.ts
+++ b/projects/ngneat/reactive-forms/src/lib/utils.ts
@@ -25,12 +25,13 @@ export function wrapIntoObservable<T>(value: T | Promise<T> | Observable<T>): Ob
 }
 
 export function mergeErrors<E>(existing: Partial<E>, toAdd: Partial<E>) {
-  return existing
-    ? {
-        ...existing,
-        ...toAdd
-      }
-    : toAdd;
+  if (!existing && !toAdd) {
+    return null;
+  }
+  return {
+    ...existing,
+    ...toAdd
+  };
 }
 
 export function removeError<E>(errors: E, key: keyof E) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

I have always found annoying that built-in reactive forms only provide a setter for errors and not a way to merge new errors with already existing ones.
So I write a little helper for that and also added tests for setErrors that weren't covered so far.

I usually tend to prefer using Validator and AsyncValidator in order to avoid managing these kind of things manually.
But it is sometime useful to do so (e.g. to debounce a time or resource-consuming HTTP backend validation while keeping simple validator triggered on change).
In that case these helpers can be useful.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: I didn't open a issue for this, but I still can if you want for tracking purpose

## What is the new behavior?

`FormArray`, `FormControl` and `FormGroup` have new methods: `mergeErrors` and a `removeError`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
