### PR TITLE
fix: accept deep partials in patchValue and reset methods

### DIFF
--- a/projects/ngneat/reactive-forms/src/lib/formArray.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.ts
@@ -30,7 +30,8 @@ import {
   ValidatorOrOpts,
   ControlValue,
   AbstractControlOf,
-  ValidatorFn
+  ValidatorFn,
+  DeepPartial
 } from './types';
 import { coerceArray, mergeErrors, removeError } from './utils';
 
@@ -101,8 +102,11 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     super.setValue(valueOrObservable, options);
   }
 
-  patchValue(valueOrObservable: Observable<Partial<ControlValue<T>>[]>, options?: ControlEventOptions): Subscription;
-  patchValue(valueOrObservable: Partial<ControlValue<T>>[], options?: ControlEventOptions): void;
+  patchValue(
+    valueOrObservable: Observable<DeepPartial<ControlValue<T>>[]>,
+    options?: ControlEventOptions
+  ): Subscription;
+  patchValue(valueOrObservable: DeepPartial<ControlValue<T>>[], options?: ControlEventOptions): void;
   patchValue(valueOrObservable: any, options?: ControlEventOptions): Subscription | void {
     if (isObservable(valueOrObservable)) {
       return valueOrObservable.subscribe((value: T[]) => super.patchValue(value, options));

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.ts
@@ -39,7 +39,8 @@ import {
   ControlsValue,
   AbstractControlsOf,
   PersistOptions,
-  ValidatorFn
+  ValidatorFn,
+  DeepPartial
 } from './types';
 import { coerceArray, mergeErrors, removeError, wrapIntoObservable } from './utils';
 import { FormArray } from './formArray';
@@ -166,8 +167,8 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     super.setValue(valueOrObservable, options);
   }
 
-  patchValue(valueOrObservable: Observable<Partial<ControlsValue<T>>>, options?: ControlEventOptions): Subscription;
-  patchValue(valueOrObservable: Partial<ControlsValue<T>>, options?: ControlEventOptions): void;
+  patchValue(valueOrObservable: Observable<DeepPartial<ControlsValue<T>>>, options?: ControlEventOptions): Subscription;
+  patchValue(valueOrObservable: DeepPartial<ControlsValue<T>>, options?: ControlEventOptions): void;
   patchValue(valueOrObservable: any, options?: ControlEventOptions): Subscription | void {
     if (isObservable(valueOrObservable)) {
       return valueOrObservable.subscribe(value => super.patchValue(value, options));
@@ -217,7 +218,7 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     markAllDirty(this);
   }
 
-  reset(formState?: Partial<ControlsValue<T>>, options?: ControlEventOptions): void {
+  reset(formState?: DeepPartial<ControlsValue<T>>, options?: ControlEventOptions): void {
     super.reset(formState, options);
   }
 

--- a/projects/ngneat/reactive-forms/src/lib/type-tests/formArray.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/type-tests/formArray.spec.ts
@@ -1,9 +1,5 @@
 import { expectTypeOf } from 'expect-type';
-import {
-  Observable,
-  of,
-  Subscription
-} from 'rxjs';
+import { Observable, of, Subscription } from 'rxjs';
 import { FormArray } from '../formArray';
 import { FormControl } from '../formControl';
 import { FormGroup } from '../formGroup';
@@ -33,7 +29,7 @@ test('control value should be of type User[]', () => {
 test('control value should be constructed according to generic control type', () => {
   const control = new FormArray<FormGroup<NestedFormControls>>([]);
   expectTypeOf<NestedForm[]>(control.value).toEqualTypeOf([nestedFormValue]);
-})
+});
 
 test('control valueChanges$ should be of type stream of User[]', () => {
   const control = new FormArray<User>([]);
@@ -70,6 +66,11 @@ test('control setValue should accept value of type User[] or stream of User[]', 
 test('control patchValue should accept value of type User[] or stream of User[]', () => {
   const control = new FormArray<User>([]);
   expectTypeOf(control.patchValue(of([user]))).toEqualTypeOf(new Subscription());
+});
+
+test('control patchValue should accept nested partials', () => {
+  const control = new FormArray<NestedForm>([]);
+  expectTypeOf(control.patchValue(of([{ b: { c: [2] } }]))).toEqualTypeOf(new Subscription());
 });
 
 test('control disableWhile should return subscription', () => {
@@ -195,5 +196,5 @@ test('should be able to set value to control inside group', () => {
     .at(0)
     .get('id')
     .setValue(3);
-  expectTypeOf((control.at(0)).getControl('id').value).toBeNumber();
+  expectTypeOf(control.at(0).getControl('id').value).toBeNumber();
 });

--- a/projects/ngneat/reactive-forms/src/lib/type-tests/formGroup.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/type-tests/formGroup.spec.ts
@@ -278,6 +278,18 @@ describe('with generic', () => {
     control.setValidators([required, pattern]);
   });
 
+  test('control patchValue should accept nested partials', () => {
+    const control = new FormGroup<NestedForm>({
+      a: new FormControl(22),
+      b: new FormControl({
+        a: '',
+        c: [3]
+      }),
+      d: new FormControl<boolean>()
+    });
+    expectTypeOf(control.patchValue(of({ b: { c: [4] } }))).toEqualTypeOf(new Subscription());
+  });
+
   test('should be able to set async validators', () => {
     const control = new FormGroup<User, Errors>(null);
     control.setAsyncValidators([requiredAsync, patternAsync]);

--- a/projects/ngneat/reactive-forms/src/lib/types.ts
+++ b/projects/ngneat/reactive-forms/src/lib/types.ts
@@ -56,6 +56,9 @@ export interface NgValidatorsErrors {
 
 export type BoxedValue<T> = { value: T; disabled?: boolean };
 export type OrBoxedValue<T> = T | BoxedValue<T>;
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
 
 export type Obj = { [key: string]: any };
 type ArrayType<T> = T extends Array<infer R> ? R : any;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently if we try to `patchValue` a nested form, we got a type error if missing any control in nested structure.

**Sample**:

```
this.formGroup = this.formBuilder.group({
  a: this.formBuilder.group({
    b: [1, [Validators.required]],
    c: '2'
  })
});

this.formGroup.patchValue({
  a: { c: '9' } // Error, missing "b"
});
```

**PS**: The same applies for `formGroup#reset` (the reset of `FormArray` was not using `Partial`, so I didn't touch it).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
No errors while `patchValue` for nested structures.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
