### PR TITLE
fix: handle 'any' values properly in 'ControlOf'

### DIFF
--- a/projects/ngneat/reactive-forms/src/lib/type-tests/formGroup.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/type-tests/formGroup.spec.ts
@@ -17,7 +17,7 @@ import {
   NestedFormControls
 } from './mocks.spec';
 import { Validators } from '@angular/forms';
-import { ControlsOf } from '../types';
+import { AbstractControl, ControlsOf } from '../types';
 
 test('control should be constructed with abstract controls', () => {
   expectTypeOf(FormGroup).toBeConstructibleWith({ name: new FormControl() });
@@ -136,7 +136,8 @@ describe('with generic', () => {
           a: new FormControl<number>()
         })
       ]),
-      d: new FormControl<boolean>()
+      d: new FormControl<boolean>(),
+      e: new FormControl()
     });
     expectTypeOf<{
       a: FormControl<number>;
@@ -146,6 +147,7 @@ describe('with generic', () => {
       }>;
       c: FormArray<FormGroup<{ a: FormControl<number> }>>;
       d: FormControl<boolean>;
+      e: AbstractControl;
     }>(a.controls);
   });
 
@@ -164,7 +166,8 @@ describe('with generic', () => {
         c: new FormArray<FormControl<number>>([])
       }),
       c: new FormControl<{ a: number }[]>(),
-      d: new FormControl<boolean>()
+      d: new FormControl<boolean>(),
+      e: new FormControl()
     });
     expectTypeOf<{
       a: FormControl<number>;
@@ -174,6 +177,7 @@ describe('with generic', () => {
       }>;
       c: FormControl<{ a: number }[]>;
       d: FormControl<boolean>;
+      e: AbstractControl;
     }>(a.controls);
   });
 

--- a/projects/ngneat/reactive-forms/src/lib/type-tests/mocks.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/type-tests/mocks.spec.ts
@@ -11,6 +11,7 @@ export interface NestedForm {
   };
   c?: { a: number }[];
   d?: boolean;
+  e?: any;
 }
 
 export interface NestedFormControls {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `ControlsOf` type recognizes `any` values as `FormArrays`.

![Captura de Tela 2020-11-19 às 12 02 38](https://user-images.githubusercontent.com/11965907/99683582-43a3cc80-2a5f-11eb-9f33-082da17dae8c.png)

Issue Number: Related to #59.

## What is the new behavior?
The `ControlsOf` type recognizes `any` values as `any`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```