### PR TITLE
feat(form): add merge option to validateOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ control.markAllAsDirty();
 
 ### `validateOn()`
 
-Takes an observable that emits a response, which is either `null` or an error object ([`ValidationErrors`](https://angular.io/api/forms/ValidationErrors)). The control's `setErrors()` method is called whenever the source emits.
+Takes an observable that emits a response, which is either `null` or an error object ([`ValidationErrors`](https://angular.io/api/forms/ValidationErrors)). The control's `setErrors()` method is called whenever the source emits. If you set the optional `merge` parameter to `true`, then `mergeErrors()` is called instead.
 
 ```ts
 const passwordValidator = combineLatest([

--- a/projects/ngneat/reactive-forms/src/lib/formArray.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.spec.ts
@@ -169,6 +169,18 @@ describe('FormArray', () => {
     expect(control.errors).toEqual(null);
   });
 
+  it('should merge errors on validateOn', () => {
+    const control = createArray();
+
+    const subject = new Subject<object>();
+    control.setErrors({ initialError: true });
+    control.validateOn(subject, true);
+    subject.next({ someError: true });
+    expect(control.errors).toEqual({ initialError: true, someError: true });
+    subject.next(null);
+    expect(control.errors).toEqual({ initialError: true });
+  });
+
   it('should hasErrorAndTouched', () => {
     const control = createArray(true);
     expect(control.hasErrorAndTouched('isInvalid')).toBeFalsy();

--- a/projects/ngneat/reactive-forms/src/lib/formArray.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.ts
@@ -14,7 +14,8 @@ import {
   hasErrorAndDirty,
   hasErrorAndTouched,
   markAllDirty,
-  mergeControlValidators
+  mergeControlValidators,
+  validateControlOn
 } from './control-actions';
 import {
   AsyncValidator,
@@ -182,10 +183,8 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     super.updateValueAndValidity();
   }
 
-  validateOn(observableValidation: Observable<null | object>) {
-    return observableValidation.subscribe(maybeError => {
-      this.setErrors(maybeError);
-    });
+  validateOn(observableValidation: Observable<null | object>, merge: boolean = false) {
+    return validateControlOn(this, observableValidation, merge);
   }
 
   hasError(errorCode: ExtractStrings<E>, path?: ControlPath) {

--- a/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.spec.ts
@@ -169,6 +169,17 @@ describe('FormControl', () => {
     expect(control.errors).toEqual(null);
   });
 
+  it('should merge errors on validateOn', () => {
+    const control = new FormControl<string>();
+    const subject = new Subject<object>();
+    control.setErrors({ initialError: true });
+    control.validateOn(subject, true);
+    subject.next({ someError: true });
+    expect(control.errors).toEqual({ initialError: true, someError: true });
+    subject.next(null);
+    expect(control.errors).toEqual({ initialError: true });
+  });
+
   it('should hasErrorAndTouched', () => {
     const control = new FormControl<string>('', Validators.required);
     expect(control.hasErrorAndTouched('required')).toBeFalsy();

--- a/projects/ngneat/reactive-forms/src/lib/formControl.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.ts
@@ -145,8 +145,8 @@ export class FormControl<T = any, E extends object = any> extends NgFormControl 
     super.updateValueAndValidity();
   }
 
-  validateOn(observableValidation: Observable<null | object>) {
-    return validateControlOn(this, observableValidation);
+  validateOn(observableValidation: Observable<null | object>, merge: boolean = false) {
+    return validateControlOn(this, observableValidation, merge);
   }
 
   getError<K extends ExtractStrings<E>>(errorCode: K): E[K] | null {

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.spec.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.spec.ts
@@ -267,6 +267,17 @@ describe('FormGroup', () => {
     expect(control.errors).toEqual(null);
   });
 
+  it('should merge errors on validateOn', () => {
+    const control = createGroup();
+    const subject = new Subject<object>();
+    control.setErrors({ initialError: true });
+    control.validateOn(subject, true);
+    subject.next({ someError: true });
+    expect(control.errors).toEqual({ initialError: true, someError: true });
+    subject.next(null);
+    expect(control.errors).toEqual({ initialError: true });
+  });
+
   it('should hasErrorAndTouched', () => {
     const control = createGroup(true);
     expect(control.hasErrorAndTouched('isInvalid')).toBeFalsy();

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.ts
@@ -232,8 +232,8 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     super.updateValueAndValidity();
   }
 
-  validateOn(observableValidation: Observable<null | object>) {
-    return validateControlOn(this, observableValidation);
+  validateOn(observableValidation: Observable<null | object>, merge: boolean = false) {
+    return validateControlOn(this, observableValidation, merge);
   }
 
   hasError<K1 extends keyof ControlsValue<T>>(errorCode: ExtractStrings<E>, path?: [K1]): boolean;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, when the observable passed to validateOn emits, setErrors is called.
This creates an issue, because it overwrites other, existing errors on the form control.

Issue Number: N/A

## What is the new behavior?
This PR introduces a new optional parameter to validateOn, so that the user can specify if he wants the errors to be merged into the existing errors, or if he wants the current behaviour of overwriting all existing errors.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
