### PR TITLE
fix: allow to pass options to updateValueAndValidity method

### DIFF
--- a/projects/ngneat/reactive-forms/src/lib/control-actions.ts
+++ b/projects/ngneat/reactive-forms/src/lib/control-actions.ts
@@ -1,6 +1,6 @@
 import { ValidationErrors, FormArray as NgFormArray } from '@angular/forms';
 import { defer, merge, Observable, of, Subscription } from 'rxjs';
-import { distinctUntilChanged, map, tap, debounceTime, switchMap } from 'rxjs/operators';
+import { distinctUntilChanged, map, debounceTime, switchMap } from 'rxjs/operators';
 import { FormArray } from './formArray';
 import { FormControl } from './formControl';
 import { FormGroup } from './formGroup';
@@ -11,7 +11,8 @@ import {
   ValidatorFn,
   ControlPath,
   PersistOptions,
-  ControlFactoryMap
+  ControlFactoryMap,
+  UpdateValueAndValidityOptions
 } from './types';
 import { coerceArray, isNil, wrapIntoObservable } from './utils';
 
@@ -110,10 +111,11 @@ export function controlEnabledWhile<T>(
 
 export function mergeControlValidators<T, Control extends AbstractControl<T>>(
   control: Control,
-  validators: ValidatorFn<T> | ValidatorFn<T>[]
+  validators: ValidatorFn<T> | ValidatorFn<T>[],
+  options?: UpdateValueAndValidityOptions
 ): void {
   control.setValidators([control.validator, ...coerceArray(validators)]);
-  control.updateValueAndValidity();
+  control.updateValueAndValidity(options);
 }
 
 export function validateControlOn<T>(control: AbstractControl<T>, validation: Observable<null | object>): Subscription {

--- a/projects/ngneat/reactive-forms/src/lib/formArray.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formArray.ts
@@ -31,7 +31,8 @@ import {
   ControlValue,
   AbstractControlOf,
   ValidatorFn,
-  DeepPartial
+  DeepPartial,
+  UpdateValueAndValidityOptions
 } from './types';
 import { coerceArray, mergeErrors, removeError } from './utils';
 
@@ -135,13 +136,13 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     return controlEnabledWhile(this, observable, options);
   }
 
-  mergeValidators(validators: Validator) {
-    mergeControlValidators(this, validators);
+  mergeValidators(validators: Validator, options?: UpdateValueAndValidityOptions) {
+    mergeControlValidators(this, validators, options);
   }
 
-  mergeAsyncValidators(validators: AsyncValidator) {
+  mergeAsyncValidators(validators: AsyncValidator, options?: UpdateValueAndValidityOptions) {
     this.setAsyncValidators([this.asyncValidator, ...coerceArray(validators)]);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(options);
   }
 
   markAsTouched(opts?: OnlySelf): void {
@@ -172,14 +173,14 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
     super.reset(value, options);
   }
 
-  setValidators(newValidator: Validator): void {
+  setValidators(newValidator: Validator, options?: UpdateValueAndValidityOptions): void {
     super.setValidators(newValidator);
-    super.updateValueAndValidity();
+    super.updateValueAndValidity(options);
   }
 
-  setAsyncValidators(newValidator: AsyncValidator): void {
+  setAsyncValidators(newValidator: AsyncValidator, options?: UpdateValueAndValidityOptions): void {
     super.setAsyncValidators(newValidator);
-    super.updateValueAndValidity();
+    super.updateValueAndValidity(options);
   }
 
   validateOn(observableValidation: Observable<null | object>) {
@@ -230,7 +231,6 @@ export class FormArray<T = any, E extends object = any> extends NgFormArray {
   }
 
   removeWhen(predicate: (element: AbstractControlOf<T>) => boolean): void {
-    const toRemove: number[] = [];
     for (let i = this.length - 1; i >= 0; --i) {
       if (predicate(this.at(i))) {
         this.removeAt(i);

--- a/projects/ngneat/reactive-forms/src/lib/formControl.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.ts
@@ -26,6 +26,7 @@ import {
   ExtractStrings,
   OnlySelf,
   OrBoxedValue,
+  UpdateValueAndValidityOptions,
   Validator,
   ValidatorFn,
   ValidatorOrOpts
@@ -98,13 +99,13 @@ export class FormControl<T = any, E extends object = any> extends NgFormControl 
     return controlEnabledWhile(this, observable, options);
   }
 
-  mergeValidators(validators: Validator) {
-    mergeControlValidators(this, validators);
+  mergeValidators(validators: Validator, options?: UpdateValueAndValidityOptions) {
+    mergeControlValidators(this, validators, options);
   }
 
-  mergeAsyncValidators(validators: AsyncValidator) {
+  mergeAsyncValidators(validators: AsyncValidator, options?: UpdateValueAndValidityOptions) {
     this.setAsyncValidators([this.asyncValidator, ...coerceArray(validators)]);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(options);
   }
 
   markAsTouched(opts?: OnlySelf): void {
@@ -135,14 +136,14 @@ export class FormControl<T = any, E extends object = any> extends NgFormControl 
     super.reset(formState, options);
   }
 
-  setValidators(newValidator: Validator): void {
+  setValidators(newValidator: Validator, options?: UpdateValueAndValidityOptions): void {
     super.setValidators(newValidator);
-    super.updateValueAndValidity();
+    super.updateValueAndValidity(options);
   }
 
-  setAsyncValidators(newValidator: AsyncValidator): void {
+  setAsyncValidators(newValidator: AsyncValidator, options?: UpdateValueAndValidityOptions): void {
     super.setAsyncValidators(newValidator);
-    super.updateValueAndValidity();
+    super.updateValueAndValidity(options);
   }
 
   validateOn(observableValidation: Observable<null | object>) {

--- a/projects/ngneat/reactive-forms/src/lib/formGroup.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formGroup.ts
@@ -40,7 +40,8 @@ import {
   AbstractControlsOf,
   PersistOptions,
   ValidatorFn,
-  DeepPartial
+  DeepPartial,
+  UpdateValueAndValidityOptions
 } from './types';
 import { coerceArray, mergeErrors, removeError, wrapIntoObservable } from './utils';
 import { FormArray } from './formArray';
@@ -185,13 +186,13 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     return controlEnabledWhile(this, observable, options);
   }
 
-  mergeValidators(validators: Validator) {
-    mergeControlValidators(this, validators);
+  mergeValidators(validators: Validator, options?: UpdateValueAndValidityOptions) {
+    mergeControlValidators(this, validators, options);
   }
 
-  mergeAsyncValidators(validators: AsyncValidator) {
+  mergeAsyncValidators(validators: AsyncValidator, options?: UpdateValueAndValidityOptions) {
     this.setAsyncValidators([this.asyncValidator, ...coerceArray(validators)]);
-    this.updateValueAndValidity();
+    this.updateValueAndValidity(options);
   }
 
   markAsTouched(opts?: OnlySelf): void {
@@ -222,14 +223,14 @@ export class FormGroup<T extends Obj = any, E extends object = any> extends NgFo
     super.reset(formState, options);
   }
 
-  setValidators(newValidator: Validator): void {
+  setValidators(newValidator: Validator, options?: UpdateValueAndValidityOptions): void {
     super.setValidators(newValidator);
-    super.updateValueAndValidity();
+    super.updateValueAndValidity(options);
   }
 
-  setAsyncValidators(newValidator: AsyncValidator): void {
+  setAsyncValidators(newValidator: AsyncValidator, options?: UpdateValueAndValidityOptions): void {
     super.setAsyncValidators(newValidator);
-    super.updateValueAndValidity();
+    super.updateValueAndValidity(options);
   }
 
   validateOn(observableValidation: Observable<null | object>) {

--- a/projects/ngneat/reactive-forms/src/lib/types.ts
+++ b/projects/ngneat/reactive-forms/src/lib/types.ts
@@ -159,3 +159,5 @@ export interface PersistOptions<T> {
   manager?: PersistManager<T>;
   arrControlFactory?: ControlFactoryMap<T>;
 }
+
+export type UpdateValueAndValidityOptions = Pick<ControlOptions, 'onlySelf' | 'emitEvent'>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #66

## What is the new behavior?

We can pass options to updateValueAndValidity when calling methods which use it.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
