### PR TITLE
fix(control): avoid throw of error with async validator

### DIFF
--- a/projects/ngneat/reactive-forms/src/lib/formControl.ts
+++ b/projects/ngneat/reactive-forms/src/lib/formControl.ts
@@ -1,4 +1,4 @@
-import { AbstractControl, FormControl as NgFormControl } from '@angular/forms';
+import { FormControl as NgFormControl } from '@angular/forms';
 import { isObservable, Observable, Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 import {
@@ -159,7 +159,17 @@ export class FormControl<T = any, E extends object = any> extends NgFormControl 
   }
 
   setErrors(errors: Partial<E> | null, opts: EmitEvent = {}) {
-    this.errorsSubject.next(errors);
+    /**
+     * @description
+     * Use an elvis operator to avoid a throw when the control is used with an async validator
+     * Which will be instantly resolved (like with `of(null)`)
+     * In such case, Angular will call this method instantly before even instancing the properties causing the throw
+     * Can be easily reproduced with a step-by-step debug once compiled when checking the stack trace of the constructor
+     *
+     * Issue: https://github.com/ngneat/reactive-forms/issues/91
+     * Reproduction: https://codesandbox.io/embed/github/C0ZEN/ngneat-reactive-forms-error-issue-cs/tree/main/?autoresize=1&expanddevtools=1&fontsize=14&hidenavigation=1&theme=dark
+     */
+    this.errorsSubject?.next(errors);
     return super.setErrors(errors, opts);
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit 
- [ ] Tests for the changes have been added (for bug fixes / features) → tried but not able to come up with a reproduction
- [ ] Docs have been added / updated (for bug fixes / features) → not needed IMO

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When creating a control with an async validator instantly resolved with for example `of(null)`, the extended class (Angular native control) will call the method internally during the class instantiation through the `super` causing a throw of error since the code except that the `setErrors` has a valid not nil `errorsSubject`.
The constructor is creating just after this the subject.

Issue Number: #91

## What is the new behavior?

The control's method `setErrors` will no longer throw an error when `errorsSubject` is not yet created.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Fixes #91 