### PR TITLE
docs(readme): fix link and update FormBuilder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,9 +472,11 @@ We also introduce a `typed` version of `FormBuilder` which returns a `typed` `Fo
 ```ts
 import { FormBuilder } from '@ngneat/reactive-forms';
 
-const fb = new FormBuilder();
+constructor(
+  private fb: FormBuilder
+) {}
 
-const group = fb.group({ name: 'ngneat', id: 1 });
+const group = this.fb.group({ name: 'ngneat', id: 1 });
 
 group.get('name') // FormControl<string>
 ```
@@ -560,4 +562,4 @@ We provide a special lint rule that forbids the imports of any token we expose, 
 `ValidatorFn`,
 from `@angular/forms`.
 
-Check out the [documentation](https://github.com/ngneat/reactive-forms/tree/master/projects/ngneat/eslint-plugin-reactive-forms).
+Check out the [documentation](https://github.com/ngneat/reactive-forms/tree/master/libs/eslint-plugin-reactive-forms).


### PR DESCRIPTION
Fixes the link and updates FormBuilder example to be more in line with Angular guide.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/reactive-forms/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What was changed?

1. Updates broken link.
2. Updates example for FormBuilder. Examples for FormBuilder in Angular guide usually show FormBuilder being injected via constructor. It may not be immediately obvious to people that `reactive-forms` supports that too. At least it wasn't obvious for me, because usually 3rd part packages require a module to be imported somewhere to make services available.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
