### PR TITLE
fix: markAllDirty(FormGroup) not marking children

### DIFF
--- a/libs/reactive-forms/src/lib/core.ts
+++ b/libs/reactive-forms/src/lib/core.ts
@@ -134,5 +134,5 @@ export function controlErrorChanges$(
 export function markAllDirty(control: AbstractControl): void {
   control.markAsDirty({ onlySelf: true });
 
-  (control as any)._forEachChild((control: any) => control.markAllAsDirty?.());
+  (control as any)._forEachChild((control: any) => control.markAllAsDirty?.() || control.markAsDirty({ onlySelf: true }));
 }

--- a/libs/reactive-forms/src/lib/form-group.spec.ts
+++ b/libs/reactive-forms/src/lib/form-group.spec.ts
@@ -196,6 +196,20 @@ describe('FormGroup Functionality', () => {
     expect(spy).toHaveBeenCalledWith(false);
   });
 
+  function areAllAllChildrenDirty(control: AbstractControl) {
+    expect(control.dirty).toBe(true);
+    (control as any)._forEachChild((control: AbstractControl) => areAllAllChildrenDirty(control));
+  }
+
+  it('should markAllAsDirty', () => {
+    const control = createGroup();
+
+    jest.spyOn(control, 'markAsDirty');
+    control.markAllAsDirty();
+    expect(control.markAsDirty).toHaveBeenCalled();
+    areAllAllChildrenDirty(control);
+  });
+
   it('should reset', () => {
     const control = createGroup();
     jest.spyOn(control, 'reset');


### PR DESCRIPTION
FormControl doesn't have a markAllAsDirty method

Closes #135

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/reactive-forms/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #135 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
