### PR TITLE
fix: markAsTouched typings to handle onlySelf argument

### DIFF
--- a/libs/reactive-forms/src/lib/form-array.ts
+++ b/libs/reactive-forms/src/lib/form-array.ts
@@ -140,8 +140,8 @@ export class FormArray<
   }
 
   markAsTouched(
-    ...opts: Parameters<UntypedFormArray['markAllAsTouched']>
-  ): ReturnType<UntypedFormArray['markAllAsTouched']> {
+    ...opts: Parameters<UntypedFormArray['markAsTouched']>
+  ): ReturnType<UntypedFormArray['markAsTouched']> {
     super.markAsTouched(...opts);
     this.touchChanges.next(true);
   }

--- a/libs/reactive-forms/src/lib/form-control.ts
+++ b/libs/reactive-forms/src/lib/form-control.ts
@@ -96,8 +96,8 @@ export class FormControl<T> extends UntypedFormControl {
   }
 
   markAsTouched(
-    ...opts: Parameters<AbstractControl['markAllAsTouched']>
-  ): ReturnType<AbstractControl['markAllAsTouched']> {
+    ...opts: Parameters<AbstractControl['markAsTouched']>
+  ): ReturnType<AbstractControl['markAsTouched']> {
     super.markAsTouched(...opts);
     this.touchChanges.next(true);
   }

--- a/libs/reactive-forms/src/lib/form-group.ts
+++ b/libs/reactive-forms/src/lib/form-group.ts
@@ -124,8 +124,8 @@ export class FormGroup<T extends Record<string, any>> extends UntypedFormGroup {
   }
 
   markAsTouched(
-    ...opts: Parameters<AbstractControl['markAllAsTouched']>
-  ): ReturnType<AbstractControl['markAllAsTouched']> {
+    ...opts: Parameters<AbstractControl['markAsTouched']>
+  ): ReturnType<AbstractControl['markAsTouched']> {
     super.markAsTouched(...opts);
     this.touchChanges.next(true);
   }


### PR DESCRIPTION
`FormControl#markAsTouched` and others can't handle options argument with `onlySelf?: boolean` ([but it should](https://angular.io/api/forms/FormControl)) due to wrong type annotation.

```
const contol = new FormControl<string>('');

contol.markAsTouched({ onlySelf: true }); // Error: Expected 0 arguments, but got 1.
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/reactive-forms/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
