### PR TITLE
fix(typings): correctly unpack values of nested form group arrays

### DIFF
--- a/libs/reactive-forms/src/lib/types.ts
+++ b/libs/reactive-forms/src/lib/types.ts
@@ -19,7 +19,11 @@ export type ValuesOf<T extends ControlsOf<any>> = {
   ? R
   : NonUndefined<T[K]> extends FormGroup<infer R>
   ? ValuesOf<R>
-  : NonUndefined<T[K]> extends FormArray<infer R, infer C> ? R[] : NonUndefined<T[K]>;
+  : NonUndefined<T[K]> extends FormArray<infer R, infer C>
+  ? R extends Record<any, any>
+    ? ValuesOf<R>[]
+    : R[]
+  : NonUndefined<T[K]>;
 };
 
 export type DeepPartial<T> = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/reactive-forms/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Minor fix for existing tying of `ValuesOf` for nested `FormArray<FormGroup>`.


```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Assuming the following FormType:
```ts
export interface FormType {
  items: {
    tags: FormControl<string[]>
  }[]
}
```

When using `ValuesOf<ControlsOf<FormType>>` the `tags` has the type ` FormControl<string[]>` instead of  `string[]`. 


Issue Number: N/A

## What is the new behavior?

The typing now correctly unpacks the values of FormGroup nested in FormArrays.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

Users might encounter a breaking change if they have the above scenario AND rely on the current incorrect typing. Fixing resulting errors is likely low effort

## Other information
