### PR TITLE
fix(typings): correctly extract nested oprional form group array typing

### DIFF
--- a/libs/reactive-forms/src/lib/types.ts
+++ b/libs/reactive-forms/src/lib/types.ts
@@ -21,7 +21,7 @@ export type ValuesOf<T extends ControlsOf<any>> = {
   ? ValuesOf<R>
   : NonUndefined<T[K]> extends FormArray<infer R, infer C>
   ? R extends Record<any, any>
-    ? ValuesOf<R>[]
+    ? ValuesOf<ControlsOf<R>>[]
     : R[]
   : NonUndefined<T[K]>;
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/reactive-forms/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

This PR addresses an edge case the previous PR #180 did not cover.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Assuming the current Formtype:
```
export interface FormType {
  items: {
    tags?: FormControl<string[] | null>
  }[]
}
```

When using `ValuesOf<ControlsOf<FormType>>`,  `tags` has the type  `string[] | null` instead of `string[] | null | undefined`.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
