### PR TITLE
feat: only emit value when control is valid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,14 @@
-name: '@ngneat/reactive-forms'
+name: 'lothern/reactive-forms'
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
   pull_request:
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ const control = new FormControl('');
 control.value$.subscribe(value => ...);
 ```
 
+### `validValue$`
+
+Similar to value$; Observes the control's value and **only** emits if the control is valid.
+
+```ts
+import { FormControl } from '@ngneat/reactive-forms';
+
+const control = new FormControl(null, [Validators.required]);
+control.validValue$.subscribe(value => ...);
+```
+
 ### `disabled$`
 
 Observes the control's `disable` status.

--- a/libs/reactive-forms/src/lib/core.ts
+++ b/libs/reactive-forms/src/lib/core.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, ValidationErrors } from '@angular/forms';
 import { defer, merge, Observable, of, Subscription } from 'rxjs';
-import { distinctUntilChanged, map } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 
 export function selectControlValue$<T, R>(
   control: any,
@@ -18,6 +18,15 @@ export function controlValueChanges$<T>(
   return merge(
     defer(() => of(control.getRawValue())),
     control.valueChanges.pipe(map(() => control.getRawValue()))
+  ) as Observable<T>;
+}
+
+export function controlValidValueChanges$<T>(
+  control: AbstractControl & { getRawValue: () => T }
+): Observable<T> {
+  return merge(
+    defer(() => of(control.getRawValue())),
+    control.valueChanges.pipe(filter(() => control.valid), map(() => control.getRawValue()))
   ) as Observable<T>;
 }
 

--- a/libs/reactive-forms/src/lib/form-array.spec.ts
+++ b/libs/reactive-forms/src/lib/form-array.spec.ts
@@ -1,7 +1,7 @@
 import { Validators } from '@angular/forms';
 import { expectTypeOf } from 'expect-type';
 import { Observable, of, Subject, Subscription } from 'rxjs';
-import {ControlsOf, FormControl, FormGroup, ValuesOf} from '..';
+import {ControlsOf, FormControl, FormGroup} from '..';
 import { ControlState } from './core';
 import { FormArray } from './form-array';
 
@@ -224,6 +224,13 @@ const createArray = (withError = false) => {
   );
 };
 
+const createInvalidArray = (withError = false) => {
+  return new FormArray<string | null>(
+    [new FormControl(null, Validators.required), new FormControl(null, Validators.required)],
+    withError ? errorFn : []
+  );
+};
+
 describe('FormArray Functionality', () => {
   it('should valueChanges$', () => {
     const control = createArray();
@@ -238,6 +245,25 @@ describe('FormArray Functionality', () => {
     expect(spy).toHaveBeenCalledWith(['1', '2', '3', '']);
     control.removeAt(1);
     expect(spy).toHaveBeenCalledWith(['1', '3', '']);
+  });
+
+  it('should validValueChanges$', () => {
+    const control = createInvalidArray();
+    const spy = jest.fn();
+    control.validValue$.subscribe(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+    control.patchValue(['1', '2']);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(['1', '2']);
+    control.push(new FormControl('3', Validators.required));
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledWith(['1', '2', '3']);
+    control.push(new FormControl(null, Validators.required));
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).not.toHaveReturnedWith(['1', '2', '3', null]);
+    control.removeAt(3);
+    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledWith(['1', '2', '3']);
   });
 
   it('should disabledChanges$', () => {

--- a/libs/reactive-forms/src/lib/form-array.ts
+++ b/libs/reactive-forms/src/lib/form-array.ts
@@ -18,6 +18,7 @@ import {
   disableControl,
   enableControl,
   markAllDirty,
+  controlValidValueChanges$,
 } from './core';
 import { DeepPartial } from './types';
 
@@ -46,6 +47,7 @@ export class FormArray<
     .asObservable()
     .pipe(distinctUntilChanged());
   readonly value$ = controlValueChanges$<Array<ValueOfControl<Control>>>(this);
+  readonly validValue$ = controlValidValueChanges$<Array<ValueOfControl<Control>>>(this);
   readonly disabled$ = controlStatus$(this, 'disabled');
   readonly enabled$ = controlStatus$(this, 'enabled');
   readonly invalid$ = controlStatus$(this, 'invalid');

--- a/libs/reactive-forms/src/lib/form-control.spec.ts
+++ b/libs/reactive-forms/src/lib/form-control.spec.ts
@@ -14,6 +14,19 @@ describe('FormControl Functionality', () => {
     expect(spy).toHaveBeenCalledWith('patched');
   });
 
+  it('should validValueChanges$', () => {
+    const control = new FormControl<string | null>(null, Validators.required);
+    const spy = jest.fn();
+    control.validValue$.subscribe(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+    control.patchValue('patched');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith('patched');
+    control.patchValue('');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).not.toHaveBeenCalledWith('');
+  });
+
   it('should disabledChanges$', () => {
     const control = new FormControl<string>();
     const spy = jest.fn();

--- a/libs/reactive-forms/src/lib/form-control.ts
+++ b/libs/reactive-forms/src/lib/form-control.ts
@@ -16,6 +16,7 @@ import {
   removeError,
   hasErrorAnd,
   controlErrorChanges$,
+  controlValidValueChanges$,
 } from './core';
 import { BoxedValue } from './types';
 
@@ -34,6 +35,7 @@ export class FormControl<T> extends UntypedFormControl {
     .asObservable()
     .pipe(distinctUntilChanged());
   readonly value$ = controlValueChanges$<T>(this);
+  readonly validValue$ = controlValidValueChanges$<T>(this);
   readonly disabled$ = controlStatus$(this, 'disabled');
   readonly enabled$ = controlStatus$(this, 'enabled');
   readonly invalid$ = controlStatus$(this, 'invalid');

--- a/libs/reactive-forms/src/lib/form-group.spec.ts
+++ b/libs/reactive-forms/src/lib/form-group.spec.ts
@@ -25,6 +25,18 @@ const createGroup = () => {
   );
 };
 
+const createInvalidGroup = () => {
+  return new FormGroup(
+    {
+      name: new FormControl<string | null>(null, Validators.required),
+      phone: new FormGroup({
+        num: new FormControl<number | null>(null, Validators.required),
+        prefix: new FormControl<number | null>(null, Validators.required),
+      }),
+    }
+  );
+};
+
 describe('FormGroup Functionality', () => {
   it('should valueChanges$', () => {
     const control = createGroup();
@@ -43,6 +55,49 @@ describe('FormGroup Functionality', () => {
     expect(spy).toHaveBeenCalledWith({
       name: 'changed',
       phone: { num: null, prefix: null },
+    });
+  });
+
+  it('should validValueChanges$', () => {
+    const control = createInvalidGroup();
+    const spy = jest.fn();
+    control.validValue$.subscribe(spy);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    control.patchValue({
+      name: 'jim',
+      phone: {
+        num: 0,
+        prefix: 1
+      }
+    });
+    
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith({
+      name: 'jim',
+      phone: { num: 0, prefix: 1 },
+    });
+    
+    control.patchValue({
+      name: 'changed',
+    });
+    
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledWith({
+      name: 'changed',
+      phone: { num: 0, prefix: 1 },
+    });
+
+    control.patchValue({
+      phone: {
+        num: null
+      }
+    });
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).not.toHaveBeenCalledWith({
+      name: 'changed',
+      phone: { num: null, prefix: 1 },
     });
   });
 

--- a/libs/reactive-forms/src/lib/form-group.ts
+++ b/libs/reactive-forms/src/lib/form-group.ts
@@ -10,6 +10,7 @@ import {
   controlEnabledWhile,
   controlErrorChanges$,
   controlStatus$,
+  controlValidValueChanges$,
   controlValueChanges$,
   disableControl,
   enableControl,
@@ -36,6 +37,7 @@ export class FormGroup<T extends Record<string, any>> extends UntypedFormGroup {
     .asObservable()
     .pipe(distinctUntilChanged());
   readonly value$ = controlValueChanges$<ValuesOf<T>>(this);
+  readonly validValue$ = controlValidValueChanges$<ValuesOf<T>>(this);
   readonly disabled$ = controlStatus$(this, 'disabled');
   readonly enabled$ = controlStatus$(this, 'enabled');
   readonly invalid$ = controlStatus$(this, 'invalid');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/reactive-forms/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/ngneat/reactive-forms/issues/182

Issue Number: 182

## What is the new behavior?
New property called validValue$ that only emits when a value is valid.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
